### PR TITLE
Redirect unknown URLs back to /. Better than "Cannot GET /..."

### DIFF
--- a/server.js
+++ b/server.js
@@ -320,5 +320,10 @@ if (cluster.isMaster) {
         });
     });
 
+    // Redirect unknown pages back home. We don't actually have a 404 page, for starters.
+    app.use(function(req, res, next) {
+        res.redirect(303, '/');
+    });
+
     app.listen(argv.port, argv.public ? undefined : 'localhost');
 }


### PR DESCRIPTION
It's a bit hacky, but it's better than the nasty "Cannot GET /foo" message that otherwise gets shown.

Addresses (but doesn't fix) https://github.com/TerriaJS/terriajs/issues/614