### PR TITLE
Add a version number in the UI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wwwroot/doc/
 error.log
 output.log
 npm-debug.log
+version.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2015-06-15
+
+* National Map now shows its version number when hovering the mouse over the logo on the top left corner.
+
 ### 2015-05-28
 
 * To hide the Explorer Panel at startup, the url can contain the parameter `hideEplorerPanel=1`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,6 +112,8 @@ function bundle(name, bundler, minify, catchErrors) {
         version += ' (plus local modifications)';
     }
 
+    console.log('Version is: ' + version);
+
     fs.writeFileSync('version.js', 'module.exports = \'' + version + '\';');
 
     // Combine main.js and its dependencies into a single file.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,7 +164,12 @@ function watch(name, files, minify) {
         packageCache: {}
     }));
 
-    function rebundle() {
+    function rebundle(ids) {
+        // Don't rebundle if only the version changed.
+        if (ids && ids.length === 1 && /\/version\.js$/.test(ids[0])) {
+            return;
+        }
+
         var start = new Date();
 
         var result = bundle(name, bundler, minify, true);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,8 +112,6 @@ function bundle(name, bundler, minify, catchErrors) {
         version += ' (plus local modifications)';
     }
 
-    console.log('Version is: ' + version);
-
     fs.writeFileSync('version.js', 'module.exports = \'' + version + '\';');
 
     // Combine main.js and its dependencies into a single file.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 /*global require*/
 
 var fs = require('fs');
+var spawnSync = require('spawn-sync');
 var glob = require('glob-all');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
@@ -104,6 +105,15 @@ gulp.task('prepare-terriajs', function() {
 gulp.task('default', ['lint', 'build']);
 
 function bundle(name, bundler, minify, catchErrors) {
+    // Get a version string from "git describe".
+    var version = spawnSync('git', ['describe']).stdout.toString().trim();
+    var isClean = spawnSync('git', ['diff-index', '--quiet', 'HEAD']).status === 0;
+    if (!isClean) {
+        version += ' (plus local modifications)';
+    }
+
+    fs.writeFileSync('version.js', 'module.exports = \'' + version + '\';');
+
     // Combine main.js and its dependencies into a single file.
     // The poorly-named "debug: true" causes Browserify to generate a source map.
     var result = bundler.bundle();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,7 +107,7 @@ gulp.task('default', ['lint', 'build']);
 function bundle(name, bundler, minify, catchErrors) {
     // Get a version string from "git describe".
     var version = spawnSync('git', ['describe']).stdout.toString().trim();
-    var isClean = spawnSync('git', ['diff-index', '--quiet', 'HEAD']).status === 0;
+    var isClean = spawnSync('git', ['status', '--porcelain']).stdout.toString().length === 0;
     if (!isClean) {
         version += ' (plus local modifications)';
     }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@
 
 /*global require*/
 
+var version = require('./version');
+
 var configuration = {
     terriaBaseUrl: 'build/TerriaJS',
     cesiumBaseUrl: undefined, // use default
@@ -140,7 +142,7 @@ terria.start({
     // Create the brand bar.
     BrandBarViewModel.create(ui, {
         elements: [
-            '<a target="_blank" href="help/About.html"><img src="images/NationalMap_Logo_RGB72dpi_REV_Blue text_BETA.png" height="50" alt="National Map" /></a>',
+            '<a target="_blank" href="help/About.html"><img src="images/NationalMap_Logo_RGB72dpi_REV_Blue text_BETA.png" height="50" alt="National Map" title="Version: ' + version + '" /></a>',
             '<a target="_blank" href="http://www.gov.au/"><img src="images/AG-Rvsd-Stacked-Press.png" height="45" alt="Australian Government" /></a>'
         ]
     });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-watch": "^4.2.4",
     "less": "^2.5.0",
     "less-plugin-npm-import": "^2.0.0",
+    "spawn-sync": "^1.0.11",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",


### PR DESCRIPTION
The version is accessible by hovering the mouse over the NM logo in the top left corner of the screen.

The version number comes from the output of [git describe](http://git-scm.com/docs/git-describe) so for production releases it should just be one of our date version tags (e.g. `2015-05-28`).  For non-labelled builds, it shows the closest label (2015-05-28 in the screenshot below), the number of commits since that label (5), and the abbreviated hash of the head commit (g5604331).  If there are local modifications beyond what is checked into git, `(plus local modifications)` is added to the end.

![image](https://cloud.githubusercontent.com/assets/924374/7877776/92052d04-0622-11e5-9489-ffd712f1b161.png)