### PR TITLE
Rename Legend tab back to Now Viewing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,6 @@ Change Log
 * National Map now shows its version number when hovering the mouse over the logo on the top left corner.
 * Added a longer disclaimer to printed versions of the map.
 * Added a Related Maps button and panel.  It currently contains links to AREMI and to the Northern Australia map.
-* Renamed the Now Viewing tab to Legend.
 * Added a small popup to call attention to the Legend tab the first time a catalog item is enabled.
 
 ### 2015-05-28

--- a/index.js
+++ b/index.js
@@ -260,7 +260,6 @@ terria.start({
     });
 
     var nowViewingTab = new NowViewingTabViewModel({
-        name: 'Legend',
         nowViewing: terria.nowViewing
     });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "proj4js-defs": "^0.0.1",
     "request": "^2.55.0",
     "supervisor": "^0.6.0",
-    "terriajs": "1.0.19",
+    "terriajs": "git://github.com/TerriaJS/terriajs#searchIcon",
     "terriajs-cesium": "1.10.5",
     "yargs": "^3.8.0"
   },


### PR DESCRIPTION
At Bill's request, given that ABS support will be adding a bunch of non-legend stuff to that tab in this release.  We can revisit afterward.