### PR TITLE
Download Roboto Mono font over https, too.

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -15,7 +15,7 @@
     <!-- Fonts -->
     <link href='//fonts.googleapis.com/css?family=Roboto:300italic,400,300' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Roboto+Condensed:300italic,400,300' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Mono:400,300' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Roboto+Mono:400,300' rel='stylesheet' type='text/css'>
 
     <!-- Leaflet -->
     <script>L_PREFER_CANVAS = true;</script>


### PR DESCRIPTION
It was hardcoded to `http`, which caused a warning in the browser console when accessing the app over `https`.