### PR TITLE
Fix fonts not loading over https.

### DIFF
--- a/wwwroot/About.html
+++ b/wwwroot/About.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>About NationalMap</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='help/NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
     <style type="text/css">

--- a/wwwroot/help/DataCatalogueTab.html
+++ b/wwwroot/help/DataCatalogueTab.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>NationalMap: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
 

--- a/wwwroot/help/FrequentlyAskedQuestions.html
+++ b/wwwroot/help/FrequentlyAskedQuestions.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>NationalMap: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
 

--- a/wwwroot/help/Help.html
+++ b/wwwroot/help/Help.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>NationalMap: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
   </head>

--- a/wwwroot/help/HowTo.html
+++ b/wwwroot/help/HowTo.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>NationalMap: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
 

--- a/wwwroot/help/NowViewingTab.html
+++ b/wwwroot/help/NowViewingTab.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>National Map: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
   </head>

--- a/wwwroot/help/SearchTab.html
+++ b/wwwroot/help/SearchTab.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>National Map: Help</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
     <meta charset="UTF-8">
   </head>

--- a/wwwroot/help/TableOfContents.html
+++ b/wwwroot/help/TableOfContents.html
@@ -4,14 +4,14 @@
     <meta http-equiv="content-type" content="text/html; charset=windows-1250">
     <meta name="generator" content="PSPad editor, www.pspad.com">
     <title>Table of Contents</title>
-    
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
+
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=latin,cyrillic-ext' rel='stylesheet' type='text/css'>
     <link href='NMStyle.css' rel='stylesheet' type='text/css'>
   </head>
-  
+
   <body>
       <h1>National Map Help</h1>
-      
+
       <h2><a target="_parent" href="Help.html">Map Navigation and Display</a>
             <br><expl>Zooming, panning, perspectives and base maps</expl></h2>
       <h2><a target="_parent" href="DataCatalogueTab.html">Data Catalogue Tab</a>
@@ -30,6 +30,6 @@
          <h3><a target="_parent" href="FrequentlyAskedQuestions.html#FAQsaboutNationalMapOperation">FAQs about National Map Operation</a></h3>
          <h3><a target="_parent" href="FrequentlyAskedQuestions.html#FAQsabouttheNationalMapsystemanddata">FAQs about the National Map system and data</a></h3>
          <h3><a target="_parent" href="FrequentlyAskedQuestions.html#FAQsaboutreportingissues">FAQs about reporting issues</a></h3>
-         
+
   </body>
 </html>


### PR DESCRIPTION
The fonts on all the help pages are hardcoded to ```http```, this will not work over ```https```` connections.

Currently https://nationalmap.gov.au/ will not use the specified font (at least in Google Chrome).