### PR TITLE
Dataset updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 2015-06-29
+
+* Renamed "Gravity Image" to "Gravity Anomaly" and update it to load from the new server (the old one is deprecated).
+* Renamed "Magnetic Image" to "Magnetic Intensity" and update it to load from the new server (the old one is deprecated).
+* Update the layer name used to access "SRTM 1 sec DEM Image".  The old one worked but was not advertised in the WMS server's GetCapabilities, which limited the quality of the metadata.
+
 ### 2015-06-24
 
 * Updated the favicon.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,9 @@ Change Log
 
 ### 2015-06-29
 
-* Renamed "Gravity Image" to "Gravity Anomaly" and update it to load from the new server (the old one is deprecated).
-* Renamed "Magnetic Image" to "Magnetic Intensity" and update it to load from the new server (the old one is deprecated).
-* Update the layer name used to access "SRTM 1 sec DEM Image".  The old one worked but was not advertised in the WMS server's GetCapabilities, which limited the quality of the metadata.
+* Renamed "Gravity Image" to "Gravity Anomaly" and updated it to load from the new server (the old one is deprecated).
+* Renamed "Magnetic Image" to "Magnetic Intensity" and updated it to load from the new server (the old one is deprecated).
+* Updated the layer name used to access "SRTM 1 sec DEM Image".  The old one worked but was not advertised in the WMS server's GetCapabilities, which limited the quality of the metadata.
 
 ### 2015-06-24
 

--- a/datasources/00_National_Data_Sets/00_01_Elevation.json
+++ b/datasources/00_National_Data_Sets/00_01_Elevation.json
@@ -61,7 +61,7 @@
               "name": "Spot Elevations"
             },
             {
-              "layers": "0",
+              "layers": "dem_s_1s",
               "url": "http://www.ga.gov.au/gisimg/services/topography/dem_s_1s/ImageServer/WMSServer",
               "type": "wms",
               "rectangle": [

--- a/datasources/00_National_Data_Sets/00_06_Land.json
+++ b/datasources/00_National_Data_Sets/00_06_Land.json
@@ -21,17 +21,12 @@
               "dataUrlType": "direct"
             },
             {
-              "url": "http://www.ga.gov.au/gis/rest/services/earth_observation/Gravity_Image_WM/MapServer",
+              "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer",
               "type": "esri-mapServer",
-              "rectangle": [
-                "105.930454436693",
-                "-43.74050960205765",
-                "162.097118856693",
-                "-7.92768801894694"
-              ],
               "dataCustodian": "[Geoscience Australia](http://www.ga.gov.au/)",
               "description": "[Licence](http://www.ga.gov.au/copyright)",
-              "name": "Gravity Image"
+              "name": "Gravity Anomaly",
+              "layers": "GravityAnomaly2010_HSI"
             },
             {
               "url": "http://www.ga.gov.au/gis/rest/services/earth_observation/Landcover_WM/MapServer",
@@ -47,17 +42,12 @@
               "name": "Land Cover"
             },
             {
-              "url": "http://www.ga.gov.au/gis/rest/services/earth_observation/Magnetic_Image_WM/MapServer",
+              "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer",
               "type": "esri-mapServer",
-              "rectangle": [
-                "106",
-                "-52",
-                "172",
-                "-8"
-              ],
               "dataCustodian": "[Geoscience Australia](http://www.ga.gov.au/)",
               "description": "[Licence](http://www.ga.gov.au/copyright)",
-              "name": "Magnetic Image"
+              "name": "Magnetic Intensity",
+              "layers": "TotalMagneticIntensity2015_HSI"
             },
             {
               "url": "http://www.ga.gov.au/gis/rest/services/earth_science/GA_Surface_Geology_of_Australia_WM/MapServer",


### PR DESCRIPTION
*  Renamed "Gravity Image" to "Gravity Anomaly" and update it to load from the new server (the old one is deprecated).
* Renamed "Magnetic Image" to "Magnetic Intensity" and update it to load from the new server (the old one is deprecated).
* Update the layer name used to access "SRTM 1 sec DEM Image".  The old one worked but was not advertised in the WMS server's GetCapabilities, which limited the quality of the metadata.
