### PR TITLE
Add support for POST requests to proxy service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2015-07-??
+
+* Added support for proxying POST requests to the proxy service.
+
 ### 2015-07-19
 
 * Default to 2D on common mobile devices in order to make the app more performant, especially on older mobile devices.

--- a/server.js
+++ b/server.js
@@ -48,9 +48,9 @@ function filterHeaders(req, headers) {
     });
 
     result['Cache-Control'] = 'public,max-age=315360000';
-    result.Expires = 'Thu, 31 Dec 2037 23:55:55 GMT';
+    result['Expires'] = 'Thu, 31 Dec 2037 23:55:55 GMT';
     result['Access-Control-Allow-Origin'] ='*';
-    delete result.pragma;
+    delete result['pragma'];
 
     return result;
 }
@@ -117,7 +117,7 @@ function doProxy(req, res, next, callback) {
     // http basic auth
     var authRequired = proxyAuth[remoteUrl.host];
     if (authRequired) {
-        filteredReqHeaders.authorization = authRequired.authorization;
+        filteredReqHeaders['authorization'] = authRequired.authorization;
     }
 
     proxiedRequest = callback(remoteUrl, filteredReqHeaders);


### PR DESCRIPTION
This was motivated by adding CSW support.  Some CSW servers can only be queried by POSTing.