### PR TITLE
Add support for varying cache durations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "proj4js-defs": "^0.0.1",
     "request": "^2.55.0",
     "supervisor": "^0.6.0",
-    "terriajs": "terriajs/terriajs#1.0.42",
+    "terriajs": "terriajs/terriajs#cacheDuration",
     "terriajs-cesium": "1.11.1",
     "yargs": "^3.8.0"
   },

--- a/server.js
+++ b/server.js
@@ -10,32 +10,6 @@ var protocolRegex = /^\w+:\//;
 var upstreamProxy;
 var bypassUpstreamProxyHosts;
 
-function getRemoteUrlFromParam(req) {
-    var remoteUrl = req.params[0];
-    if (remoteUrl.indexOf('_') === 0) {
-        remoteUrl = remoteUrl.substring(remoteUrl.indexOf('/')+1);
-    }
-    if (remoteUrl) {
-        var match = protocolRegex.exec(remoteUrl);
-        if (!match || match.length < 1) {
-            remoteUrl = 'http://' + remoteUrl;
-        } else {
-            var matchedPart = match[0];
-
-            // If the protocol portion of the URL only has a single slash after it, the extra slash was probably stripped off by someone
-            // along the way (NGINX will do this).  Add it back.
-            if (remoteUrl[matchedPart.length] !== '/') {
-                remoteUrl = matchedPart + '/' + remoteUrl.substring(matchedPart.length);
-            }
-        }
-
-        remoteUrl = url.parse(remoteUrl);
-        // copy query string
-        remoteUrl.search = url.parse(req.url).search;
-    }
-    return remoteUrl;
-}
-
 var dontProxyHeaderRegex = /^(?:Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade)$/i;
 
 function filterHeaders(req, headers) {
@@ -47,9 +21,15 @@ function filterHeaders(req, headers) {
         }
     });
 
-    result['Cache-Control'] = 'public,max-age=315360000';
-    result['Expires'] = 'Thu, 31 Dec 2037 23:55:55 GMT';
+    return result;
+}
+
+function filterResponseHeaders(req, headers, maxAgeSeconds) {
+    var result = filterHeaders(req, headers);
+
+    result['Cache-Control'] = 'public,max-age=' + maxAgeSeconds;
     result['Access-Control-Allow-Origin'] ='*';
+    delete result['Expires'];
     delete result['pragma'];
 
     return result;
@@ -70,20 +50,66 @@ function proxyAllowedHost(host) {
     return false;
 }
 
+var durationRegex = /^([\d.]+)(ms|s|m|h|d|w|y)$/;
+
+var durationUnits = {
+    ms: 1.0 / 1000,
+    s: 1.0,
+    m: 60.0,
+    h: 60.0 * 60.0,
+    d: 24.0 * 60.0 * 60.0,
+    w: 7.0 * 24.0 * 60.0 * 60.0,
+    y: 365.0 * 24.0 * 60.0 * 60.0
+};
+
 function doProxy(req, res, next, callback) {
-    // look for request like http://localhost:8080/proxy/http://example.com/file?query=1
-    var remoteUrl = getRemoteUrlFromParam(req);
-    if (!remoteUrl) {
-        // look for request like http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1
-        remoteUrl = Object.keys(req.query)[0];
-        if (remoteUrl) {
-            remoteUrl = url.parse(remoteUrl);
+    var maxAgeSeconds = 315360000; // effectively no max age.
+    var remoteUrlString = req.params[0];
+
+    if (!remoteUrlString || remoteUrlString.length === 0) {
+        return res.status(400).send('No url specified.');
+    }
+
+    // Does the proxy URL include a max age?
+    if (remoteUrlString[0] === '_') {
+        var slashIndex = remoteUrlString.indexOf('/');
+        var maxAgeString = remoteUrlString.substring(1, slashIndex);
+        remoteUrlString = remoteUrlString.substring(slashIndex + 1);
+
+        if (remoteUrlString.length === 0) {
+            return res.status(400).send('No url specified.');
+        }
+
+        // Interpret the max age as a duration in Varnish notation.
+        // https://www.varnish-cache.org/docs/trunk/reference/vcl.html#durations
+        var parsedMaxAge = durationRegex.exec(maxAgeString);
+        var value = parseFloat(parsedMaxAge[1]);
+        var unitConversion = durationUnits[parsedMaxAge[2]];
+        if (!unitConversion) {
+            return res.status(400).send('Invalid duration unit ' + parsedMaxAge[2]);
+        }
+
+        maxAgeSeconds = value * unitConversion;
+    }
+
+    // Add http:// if no protocol is specified.
+    var protocolMatch = protocolRegex.exec(remoteUrlString);
+    if (!protocolMatch || protocolMatch.length < 1) {
+        remoteUrlString = 'http://' + remoteUrlString;
+    } else {
+        var matchedPart = protocolMatch[0];
+
+        // If the protocol portion of the URL only has a single slash after it, the extra slash was probably stripped off by someone
+        // along the way (NGINX will do this).  Add it back.
+        if (remoteUrlString[matchedPart.length] !== '/') {
+            remoteUrlString = matchedPart + '/' + remoteUrlString.substring(matchedPart.length);
         }
     }
 
-    if (!remoteUrl) {
-        return res.status(400).send('No url specified.');
-    }
+    var remoteUrl = url.parse(remoteUrlString);
+
+    // Copy the query string
+    remoteUrl.search = url.parse(req.url).search;
 
     if (!remoteUrl.protocol) {
         remoteUrl.protocol = 'http:';
@@ -94,7 +120,7 @@ function doProxy(req, res, next, callback) {
         proxy = upstreamProxy;
     }
 
-    //If you want to run a CORS proxy to data source, remove this section
+    // Are we allowed to proxy for this host?
     if (!proxyAllowedHost(remoteUrl.host)) {
         res.status(400).send('Host is not in list of allowed hosts: ' + remoteUrl.host);
         return;
@@ -120,7 +146,7 @@ function doProxy(req, res, next, callback) {
         filteredReqHeaders['authorization'] = authRequired.authorization;
     }
 
-    proxiedRequest = callback(remoteUrl, filteredReqHeaders);
+    proxiedRequest = callback(remoteUrl, filteredReqHeaders, proxy, maxAgeSeconds);
 }
 
 // Include the cluster module
@@ -224,7 +250,7 @@ if (cluster.isMaster) {
     });
 
     app.get('/proxy/*', function(req, res, next) {
-        doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy) {
+        doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
             return request.get({
                 url : url.format(remoteUrl),
                 headers : filteredRequestHeaders,
@@ -235,7 +261,7 @@ if (cluster.isMaster) {
 
                 if (response) {
                     code = response.statusCode;
-                    res.header(filterHeaders(req, response.headers));
+                    res.header(filterResponseHeaders(req, response.headers, maxAgeSeconds));
                 }
 
                 res.status(code).send(body);
@@ -244,7 +270,7 @@ if (cluster.isMaster) {
     });
 
     app.post('/proxy/*', function(req, res, next) {
-        doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy) {
+        doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
             req.pipe(request.post({
                 url : url.format(remoteUrl),
                 headers : filteredRequestHeaders,
@@ -255,7 +281,7 @@ if (cluster.isMaster) {
 
                 if (response) {
                     code = response.statusCode;
-                    res.header(filterHeaders(req, response.headers));
+                    res.header(filterResponseHeaders(req, response.headers, maxAgeSeconds));
                 }
 
                 res.status(code).send(body);

--- a/server.js
+++ b/server.js
@@ -73,6 +73,10 @@ function doProxy(req, res, next, callback) {
     // Does the proxy URL include a max age?
     if (remoteUrlString[0] === '_') {
         var slashIndex = remoteUrlString.indexOf('/');
+        if (slashIndex < 0) {
+            return res.status(400).send('No url specified.');
+        }
+
         var maxAgeString = remoteUrlString.substring(1, slashIndex);
         remoteUrlString = remoteUrlString.substring(slashIndex + 1);
 

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ var durationUnits = {
 };
 
 function doProxy(req, res, next, callback) {
-    var maxAgeSeconds = 315360000; // effectively no max age.
+    var maxAgeSeconds = 1209600; // two weeks
     var remoteUrlString = req.params[0];
 
     if (!remoteUrlString || remoteUrlString.length === 0) {

--- a/server.js
+++ b/server.js
@@ -87,7 +87,15 @@ function doProxy(req, res, next, callback) {
         // Interpret the max age as a duration in Varnish notation.
         // https://www.varnish-cache.org/docs/trunk/reference/vcl.html#durations
         var parsedMaxAge = durationRegex.exec(maxAgeString);
+        if (!parsedMaxAge || parsedMaxAge.length < 3) {
+            return res.status(400).send('Invalid duration.');
+        }
+
         var value = parseFloat(parsedMaxAge[1]);
+        if (value !== value) {
+            return res.status(400).send('Invalid duration.');
+        }
+
         var unitConversion = durationUnits[parsedMaxAge[2]];
         if (!unitConversion) {
             return res.status(400).send('Invalid duration unit ' + parsedMaxAge[2]);

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -4,10 +4,10 @@
 
 # This is a basic VCL configuration file for varnish.  See the vcl(7)
 # man page for details on VCL syntax and semantics.
-# 
+#
 # Default backend definition.  Set this to point to your content
 # server.
-# 
+#
 backend default {
     .host = "127.0.0.1";
     .port = "3001";
@@ -52,16 +52,10 @@ sub vcl_fetch
 {
   if ( beresp.status >= 500 ) {
     set beresp.ttl = 0s;
-  } else if (req.url ~ "^/proxy/_0d"){
-    set beresp.ttl = 0d;
-  } else if (req.url ~ "^/proxy/_1d") {
-    set beresp.ttl = 1d;
-  } else {
-    set beresp.ttl = 14d;
   }
 }
 
-# 
+#
 # Below is a commented-out copy of the default VCL logic.  If you
 # redefine any of these subroutines, the built-in logic will be
 # appended to your code.
@@ -94,7 +88,7 @@ sub vcl_fetch
 #     }
 #     return (lookup);
 # }
-# 
+#
 # sub vcl_pipe {
 #     # Note that only the first request to the backend will have
 #     # X-Forwarded-For set.  If you use X-Forwarded-For and want to
@@ -104,11 +98,11 @@ sub vcl_fetch
 #     # applications, like IIS with NTLM authentication.
 #     return (pipe);
 # }
-# 
+#
 # sub vcl_pass {
 #     return (pass);
 # }
-# 
+#
 # sub vcl_hash {
 #     hash_data(req.url);
 #     if (req.http.host) {
@@ -118,15 +112,15 @@ sub vcl_fetch
 #     }
 #     return (hash);
 # }
-# 
+#
 # sub vcl_hit {
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_miss {
 #     return (fetch);
 # }
-# 
+#
 # sub vcl_fetch {
 #     if (beresp.ttl <= 0s ||
 #         beresp.http.Set-Cookie ||
@@ -139,11 +133,11 @@ sub vcl_fetch
 #     }
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_deliver {
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_error {
 #     set obj.http.Content-Type = "text/html; charset=utf-8";
 #     set obj.http.Retry-After = "5";
@@ -167,11 +161,11 @@ sub vcl_fetch
 # "};
 #     return (deliver);
 # }
-# 
+#
 # sub vcl_init {
 #   return (ok);
 # }
-# 
+#
 # sub vcl_fini {
 #   return (ok);
 # }

--- a/wwwroot/init/tind.json
+++ b/wwwroot/init/tind.json
@@ -23,7 +23,10 @@
             "includeEsriMapServer": false,
             "groupBy": "none",
             "useResourceName": true,
-            "isOpen": true
+            "isOpen": true,
+            "itemProperties": {
+                "cacheDuration": "1d"
+            }
         }
     ]
 }


### PR DESCRIPTION
* Change proxy in `server.js` to remove the `Expires` header entirely and to set the `max-age` in the `Cache-Control` header to the actual length of time to cache, as specified in the proxy URL (e.g. `/proxy/_1d/http://whatever` versus `/proxy/_50s/http://whatever`.
* Do not explicitly set the ttl for proxied requests the Varnish VCL file.  Varnish will set it automatically from by looking at the `Cache-Control` header.
* Cache for 14 days by default, instead of however many years.  Previously Varnish was doing this, but the headers (which are honored by web browsers and potentially other intermediate caches) were set incorrectly.
* Change `TIND.json` so that TIND tiles are cached for only 24 hours.