### PR TITLE
Include terriaJS outputs in 'gulp watch'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,8 @@ var appJSName = 'nationalmap.js';
 var appCssName = 'nationalmap.css';
 var specJSName = 'nationalmap-tests.js';
 var appEntryJSName = './index.js';
+var terriaJSSource = 'node_modules/terriajs/wwwroot';
+var terriaJSDest = 'wwwroot/build/TerriaJS';
 var testGlob = './test/**/*.js';
 
 // Create the build directory, because browserify flips out if the directory that might
@@ -87,8 +89,11 @@ gulp.task('watch-datasource-catalog', ['merge-catalog'], function() {
 
 gulp.task('watch-datasources', ['watch-datasource-groups','watch-datasource-catalog']);
 
+gulp.task('watch-terriajs', ['prepare-terriajs'], function() {
+    return gulp.watch(terriaJSSource + '/**', [ 'prepare-terriajs' ]);
+});
 
-gulp.task('watch', ['watch-app', 'watch-specs', 'watch-css', 'watch-datasources']);
+gulp.task('watch', ['watch-app', 'watch-specs', 'watch-css', 'watch-datasources', 'watch-terriajs']);
 
 gulp.task('lint', function(){
     return gulp.src(['lib/**/*.js', 'test/**/*.js'])
@@ -107,10 +112,9 @@ gulp.task('docs', function(){
 gulp.task('prepare', ['prepare-terriajs']);
 
 gulp.task('prepare-terriajs', function() {
-    return gulp.src([
-            'node_modules/terriajs/wwwroot/**'
-        ], { base: 'node_modules/terriajs/wwwroot' })
-    .pipe(gulp.dest('wwwroot/build/TerriaJS'));
+    return gulp
+        .src([ terriaJSSource + '/**' ], { base: terriaJSSource })
+        .pipe(gulp.dest(terriaJSDest));
 });
 
 gulp.task('merge-groups', function() {


### PR DESCRIPTION
Just a minor improvement so that 'gulp watch' picks up changes in TerriaJS tests etc, to make testing a bit faster.