### PR TITLE
Remove x-forwarded-host from proxied requests.

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var protocolRegex = /^\w+:\//;
 var upstreamProxy;
 var bypassUpstreamProxyHosts;
 
-var dontProxyHeaderRegex = /^(?:Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade)$/i;
+var dontProxyHeaderRegex = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade)$/i;
 
 function filterHeaders(req, headers) {
     var result = {};


### PR DESCRIPTION
In the GA deployment of NationalMap, a reverse proxy (Apache I think) forwards requests to our varnish/node proxy and adds the `x-forwarded-host` header along the way.  Our node-based proxy then blindly includes this header in the request to the proxied URL.  Usually this is fine(-ish), but some servers look at this header in the same way they might look at the `host` header: as specifying which of a set of servers hosted at the same IP address is meant to respond to the request.  If the host is not among the hostnames the server thinks it should be serving for, it will fail (e.g. with a 404).

Our node proxy explicitly filters out the `host` header from incoming requests.  It should do the same with the `x-forwarded-host` header in order to fix the problem described above, which is what this PR does.

Fixes TerriaJS/terriajs#1003
CC @keithmoss


