### PR TITLE
Downgrade Leaflet to 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.12.3",
     "formidable": "^1.0.17",
     "javascript-natural-sort": "^0.7.1",
-    "leaflet": "^0.7.3",
+    "leaflet": "0.7.3",
     "ogr2ogr": "^0.5.1",
     "proj4": "^2.3.6",
     "proj4js-defs": "^0.0.1",


### PR DESCRIPTION
Fixes TerriaJS/terriajs#1121. Related to TerriaJS/terriajs#1151.

Note: npm Leaflet 0.7.3 has incorrect L.version (0.7.2), but the installed package is actually 0.7.3 (see Leaflet/Leaflet#2735)