### PR TITLE
Remove hardcoded descriptions from the Mobile Black Spot datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2016-01-15
+
+* Removed hardcoded descriptions from the Mobile Black Spot datasets, allowing descriptions provided by the server to be used instead.
+
 ### 2015-12-15
 
 * Added Department of Environment datasets under `National Data Sets -> Environment`.

--- a/datasources/00_National_Data_Sets/00_00_Communications.json
+++ b/datasources/00_National_Data_Sets/00_00_Communications.json
@@ -212,17 +212,12 @@
               "dataUrl": "http://data.gov.au/dataset/community-reports-of-poor-or-no-mobile-coverage",
               "dataUrlType": "direct",
               "clipToRectangle": true,
-              "description": "Between December 2013 and August 2014 the Government accepted reports from individuals and community representatives about locations with poor or no mobile coverage. The reported locations have been included in a database that has been shared with mobile network operators and infrastructure providers to assist them in preparing funding proposals for the Mobile Black Spot Programme. Further information on the programme is available on the Department of Communications’ website [www.communications.gov.au/mobile_coverage](http://www.communications.gov.au/mobile_coverage). These locations have not been independently tested to verify the level of mobile coverage.<br/>[Licence](http://creativecommons.org/licenses/by/3.0/au/)",
               "name": "Mobile Black Spot Database",
               "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
               "url": "https://programs.communications.gov.au/geoserver/ows",
               "type": "wms",
               "opacity": 1.0,
               "info": [
-                {
-                  "name": "Data Description",
-                  "content": ""
-                },
                 {
                   "name": "Licence",
                   "content": "[Creative Commons Attribution 3.0 Australia (CC BY 3.0 AU)](http://creativecommons.org/licenses/by/3.0/au/)"
@@ -238,16 +233,11 @@
               "dataUrlType": "direct",
               "clipToRectangle": true,
               "name": "Mobile Black Spot Programme - Funded Base Stations",
-              "description": "The Australian Government's $100 million Mobile Black Spot Programme will deliver almost 500 new or upgraded mobile base stations around Australia - 429 Telstra base stations and 70 Vodafone base stations. The first base stations funded under the Programme will be rolled out before the end of 2015 and the rollout will continue for a three year period. The rollout sequence will be determined by Telstra and Vodafone based on various factors including obtaining local government planning approvals. Further information on the Programme is available on the Department of Communications' website www.communications.gov.au/mobile_coverage.",
               "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
               "url": "https://programs.communications.gov.au/geoserver/ows",
               "type": "wms",
               "opacity": 1.0,
               "info": [
-                {
-                  "name": "Data Description",
-                  "content": ""
-                },
                 {
                   "name": "Licence",
                   "content": "[Creative Commons Attribution 3.0 Australia (CC BY 3.0 AU)](http://creativecommons.org/licenses/by/3.0/au/)"


### PR DESCRIPTION
To allow the server-provided descriptions to be used instead.

Fixes #153 
