### PR TITLE
Explicitly use bash so that npm start works on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     ]
   },
   "scripts": {
-    "start": "./run_server.sh",
-    "stop": "./stop_server.sh",
+    "start": "bash -c \"./run_server.sh\"",
+    "stop": "bash -c \"./stop_server.sh\"",
     "postinstall": "echo 'Installation with NPM successful. What to do next:\\n  npm start       # Starts the server on port 3001\\n  gulp watch      # Builds NationalMap and dependencies, and rebuilds if files change.'"
   }
 }

--- a/run_server.sh
+++ b/run_server.sh
@@ -5,9 +5,14 @@ fi
 if [ -f terriajs.pid ]; then
     echo "Warning: server seems to be already running."
 fi
-# pkill -f terriajs-server
 date > output.log
-nohup node node_modules/terriajs-server "$@" >> output.log 2> error.log < /dev/null &
+
+if [ "`which nohup`" == "" ]; then
+    # There's no nohup on Windows. We just run node without it, which is fine in a dev environment.
+    node node_modules/terriajs-server "$@" >> output.log 2> error.log < /dev/null &
+else
+    nohup node node_modules/terriajs-server "$@" >> output.log 2> error.log < /dev/null &
+fi
 sleep 2 # Give the server a chance to fail.
 cat output.log 
 pid=$!

--- a/run_server.sh
+++ b/run_server.sh
@@ -16,7 +16,7 @@ fi
 sleep 2 # Give the server a chance to fail.
 cat output.log 
 pid=$!
-ps | grep "^\s*${pid}" > /dev/null
+ps | grep "^ *${pid}" > /dev/null
 running=$?
 if [ $running -eq 0 ]; then
     echo "(TerriaJS-Server running in background with pid $!)." && echo $pid > terriajs.pid

--- a/stop_server.sh
+++ b/stop_server.sh
@@ -1,6 +1,11 @@
 if [ -f "terriajs.pid" ]; then
-    pgrep -f terriajs-server > /dev/null && echo "(Killing old server)."
-    kill `cat terriajs.pid`
+    pid=`cat terriajs.pid`
+    ps | grep "^ *${pid}" > /dev/null
+    running=$?
+    if [ $running -eq 0 ]; then
+        echo "(Killing old server)."
+        kill $pid
+    fi
     rm terriajs.pid
 else
     echo "TerriaJS server not running."


### PR DESCRIPTION
Unfortunately npm doesn't launch scripts in bash on Windows, even if npm itself was invoked from bash (ugh).  So we have to do it explicitly.  We're already doing the same thing in package.json in TerriaJS, for what it's worth.

`npm start` still doesn't quite work, though, because `nohup` doesn't exist.