### PR TITLE
Removing some ignored files from Docker to get it to build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,7 @@
 .git
 ckanext-cesiumpreview
 node_modules
-spec
-src
 third_party
 varnish
-gulpfile.js
 npm-debug.log
 *.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 # Docker image for the primary national map application server
-FROM node:0.10-onbuild
+FROM node:5.11-onbuild
 MAINTAINER briely.marum@nicta.com.au
+
 RUN apt-get update && apt-get install -y gdal-bin
+
+# Install app dependencies
+RUN npm install -g gulp && npm install
+
+# Bundle app source
+RUN gulp
+
 EXPOSE 3001
+CMD [ "node", "node_modules/terriajs-server/lib/app.js", "--config-file", "devserverconfig.json" ]


### PR DESCRIPTION
In the dockerfile itself I switch to 5.11 nodejs and added the gulp step.  I also changed the CMD to what is underlying the `npm start` so that it doesn't exit (Docker doesn't like background processes).