### PR TITLE
Add urijs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "terriajs-catalog-editor": "^0.2.0",
     "terriajs-cesium": "1.20.0",
     "terriajs-schema": "latest",
+    "urijs": "^1.17.1",
     "webpack": "^1.12.14"
   },
   "scripts": {


### PR DESCRIPTION
Add `urijs` to package.json, since it is required by NationalMap's `lib/ViewModels/PreviewLinkViewModel.js`.