### PR TITLE
Use a new version of style-loader to work around Chrome sourcemaps bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "15.2.0",
     "redbox-react": "^1.2.3",
     "sass-loader": "^3.2.0",
-    "style-loader": "^0.13.1",
+    "style-loader": "git://github.com/TerriaJS/style-loader#chromeWorkaround",
     "svg-sprite-loader": "0.0.24",
     "terriajs": "git://github.com/TerriaJS/terriajs.git#newui",
     "terriajs-catalog-editor": "^0.2.0",


### PR DESCRIPTION
See also TerriaJS/terriajs#1771.