### PR TITLE
Remove beta, separate Australia icon from NationalMap text.

### DIFF
--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -23,7 +23,8 @@
         "appName": "NationalMap",
         "supportEmail": "data@pmc.gov.au",
         "brandBarElements(Remove this bit in parentheses for production deployment)": [
-            "<a target=\"_blank\" href=\"https://github.com/NICTA/nationalmap/wiki/New-User-Interface-Preview\"><img src=\"images/NationalMap_Logo_RGB72dpi_REV_Blue text_BETA.png\" height=\"50\" alt=\"National Map\" title=\"Version: {{version}}\" /></a>",
+            "<a target=\"_blank\" href=\"https://github.com/NICTA/nationalmap/wiki/New-User-Interface-Preview\"><img src=\"images/NationalMap-logo-only.png\" height=\"50\" alt=\"National Map\" title=\"Version: {{version}}\" /></a>",
+            "<a target=\"_blank\" href=\"https://github.com/NICTA/nationalmap/wiki/New-User-Interface-Preview\"><img src=\"images/NationalMap-text-only.png\" height=\"50\" alt=\"National Map\" title=\"Version: {{version}}\" /></a>",
             "<a target=\"_blank\" href=\"http://www.gov.au/\"><img src=\"images/AG-Rvsd-Stacked-Press.png\" height=\"45\" alt=\"Australian Government\" /></a>"
         ]
     }


### PR DESCRIPTION
So that the icon alone can be shown on a mobile device with a narrow screen.